### PR TITLE
Add country context open cage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.8-alpha.6",
+  "version": "0.1.8-alpha.7",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/geolocation/index.ts
+++ b/src/geolocation/index.ts
@@ -167,7 +167,7 @@ const getLatLngAddressWithOpenCage = async (
   const apiUrl = 'https://api.opencagedata.com/geocode/v1/json';
   const requestUrl = `${apiUrl}?key=${apikey}&q=${encodeURIComponent(
     completeAddress
-  )}&pretty=1&no_annotations=1`;
+  )}&countrycode=br&pretty=1&no_annotations=1`;
 
   try {
     log.info(


### PR DESCRIPTION
Because we didn't add a country context to open cage the api responded with results from all parts of the world, something we didn't want.

Now we pass the countrycode via params and this shouldnt happen again.

Also, if the search for ceps isnt successful via brasil api + open cage, we try to search via google maps.